### PR TITLE
Expand summarizer pipeline with dataset registry and async service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,116 @@
-
 # Text Summarizer Project
 
 ## Overview
-This project is an end-to-end text summarizer application. It uses NLP techniques to provide concise and meaningful summaries of long texts.
+This repository implements an end-to-end abstractive text summarization system. It now supports:
 
-## Workflows
-1. Update `config.yaml`
-2. Update `params.yaml`
-3. Update entity
-4. Update the configuration manager in `src/config`
-5. Update the components
-6. Update the pipeline
-7. Update `main.py`
-8. Update `app.py`
+- **Config-driven datasets** – plug in multiple summarization corpora with per-dataset schema mappings and preprocessing hooks.
+- **Reproducible ML pipeline** – ingestion, validation, transformation, training, and evaluation stages orchestrated through a single entry point.
+- **Experiment tracking & sweeps** – optional Optuna-based hyperparameter search and pluggable tracking backends (local JSONL logs by default, with optional Weights & Biases support).
+- **Async API service** – FastAPI application with cached inference pipelines and background training jobs with status reporting.
 
-## How to Run
+## Repository highlights
+- `config/config.yaml` – global settings, dataset registry, and generation defaults.
+- `params.yaml` – training arguments, hyperparameter search space, and tracking preferences.
+- `src/textSummarizer/components/*` – implementation of each pipeline stage.
+- `src/textSummarizer/pipeline/training.py` – orchestrates all stages for a selected dataset.
+- `app.py` – FastAPI service exposing dataset discovery, async training, and cached prediction endpoints.
 
-### Steps:
+## Setup
+```bash
+# clone the repo
+git clone https://github.com/atharvayeola/text-summarizer
+cd text-summarizer
 
-1. **Clone the repository**
-    ```bash
-    git clone https://github.com/atharvayeola/text-summarizer
-    ```
+# (optional) create a virtual environment
+python -m venv .venv
+source .venv/bin/activate
 
-2. **Create a conda environment after opening the repository**
-    ```bash
-    conda create -n summary python=3.8 -y
-    ```
+# install dependencies
+pip install -r requirements.txt
+```
 
-    ```bash
-    conda activate summary
-    ```
+## Configuring datasets
+`config/config.yaml` ships with `samsum` and `cnn_dailymail` entries. Each dataset defines:
 
-3. **Install the requirements**
-    ```bash
-    pip install -r requirements.txt
-    ```
+- `ingestion.type` – `zip` for remote archives or `huggingface` for datasets downloaded via the 🤗 `datasets` hub.
+- `columns` – mapping between canonical `input_text`/`target_text` keys and dataset-specific fields.
+- `splits` – logical split names (`train`, `validation`, `test`).
+- `max_input_length` / `max_target_length` – sequence lengths used during tokenization and evaluation.
 
-4. **Run the application**
-    ```bash
-    python app.py
-    ```
+Add new datasets by copying an entry and adjusting these fields. Optional `preprocessing_fn` values can point to custom cleaning functions using dotted import paths.
 
-5. **Open your local host and port to access the application**
+## Running the pipeline from the CLI
+```
+python main.py \
+  --dataset samsum \
+  --hyperparameter-search \
+  --sweep-trials 5 \
+  --experiment-name samsum-baseline
+```
+Arguments:
+- `--dataset` – dataset identifier from `config/config.yaml` (defaults to `default_dataset`).
+- `--hyperparameter-search` – enable Optuna sweeps using the search space defined in `params.yaml`.
+- `--sweep-trials` – optionally override the number of trials.
+- `--experiment-name` – tag the run for tracking artifacts and logs.
 
-## AWS CI/CD Deployment with GitHub Actions
+Artifacts are written under `artifacts/<stage>/<dataset_id>/`, including tokenized datasets, fine-tuned models, and evaluation metrics (`metrics.csv` + JSON).
+
+## Experiment tracking
+Tracking settings live in `params.yaml` under `experiment_tracking`. By default the `local` backend writes JSONL logs to `artifacts/experiments/<dataset>/<run_name>/`. Set `backend: wandb` (and install `wandb`) to stream metrics to Weights & Biases.
+
+Hyperparameter search is powered by Hugging Face `Trainer.hyperparameter_search` with an Optuna backend. The best configuration is logged to `hyperparameter_search.json` and used to retrain the final model automatically.
+
+## FastAPI service
+```
+uvicorn app:app --reload
+```
+Key endpoints:
+- `GET /datasets` – discover available datasets and their metadata.
+- `POST /train` – enqueue a background training job. Body fields mirror the CLI flags.
+- `GET /train/{job_id}` – retrieve job status (`queued`, `running`, `completed`, `failed`).
+- `GET /train` – list all submitted jobs.
+- `POST /predict` – summarize text using the cached model (`{"text": "...", "dataset_id": "samsum"}`).
+
+The service warms up the default dataset model on startup and caches pipelines per dataset for low-latency inference.
+
+## Evaluation pipeline
+The evaluation stage reloads the fine-tuned model, generates summaries with the configured decoding settings, computes ROUGE metrics, and logs the results to both CSV and JSON artifacts. Metrics are also pushed to the active experiment tracker.
+
+## AWS CI/CD (existing instructions)
+Refer to the original deployment notes below for provisioning AWS infrastructure, building Docker images, and wiring up GitHub Actions self-hosted runners.
+
+### AWS CI/CD Deployment with GitHub Actions
 
 1. **Login to AWS console.**
-
 2. **Create IAM user for deployment with specific access:**
-    - EC2 access: Virtual machine
-    - ECR: Elastic Container Registry to save your Docker image in AWS
+   - EC2 access: Virtual machine
+   - ECR: Elastic Container Registry to save your Docker image in AWS
 
-    **Description:**
-    1. Build Docker image of the source code
-    2. Push your Docker image to ECR
-    3. Launch your EC2
-    4. Pull your image from ECR in EC2
-    5. Launch your Docker image in EC2
+   **Deployment flow:**
+   1. Build Docker image of the source code
+   2. Push your Docker image to ECR
+   3. Launch your EC2
+   4. Pull your image from ECR in EC2
+   5. Launch your Docker image in EC2
 
-    **Policy:**
-    - AmazonEC2ContainerRegistryFullAccess
-    - AmazonEC2FullAccess
+   **Required policies:**
+   - `AmazonEC2ContainerRegistryFullAccess`
+   - `AmazonEC2FullAccess`
 
-3. **Create ECR repository to store/save Docker image**
-    - Save the URI: `<your ECR URI>`
-
-4. **Create EC2 machine (Ubuntu)**
-
-5. **Open EC2 and install Docker in EC2 machine:**
-    ```bash
-    sudo apt-get update -y
-    sudo apt-get upgrade
-    curl -fsSL https://get.docker.com -o get-docker.sh
-    sudo sh get-docker.sh
-    sudo usermod -aG docker ubuntu
-    newgrp docker
-    ```
-
-6. **Configure EC2 as self-hosted runner:**
-    Go to GitHub `Settings > Actions > Runners > New self-hosted runner`, choose OS, and then run commands one by one.
-
-7. **Setup GitHub secrets:**
-    - `AWS_ACCESS_KEY_ID`
-    - `AWS_SECRET_ACCESS_KEY`
-    - `AWS_REGION`: `us-east-1`
-    - `AWS_ECR_LOGIN_URI`: `demo >> <your ECR login URI>`
-    - `ECR_REPOSITORY_NAME`: `text-summarizer`
-
-## Author
-Atharva Yeola
-
-Email: atharvayeola12@gmail.com
+3. **Create ECR repository to store/save Docker image** and note the repository URI.
+4. **Create an EC2 machine (Ubuntu)** and install Docker:
+   ```bash
+   sudo apt-get update -y
+   sudo apt-get upgrade
+   curl -fsSL https://get.docker.com -o get-docker.sh
+   sudo sh get-docker.sh
+   sudo usermod -aG docker ubuntu
+   newgrp docker
+   ```
+5. **Configure the EC2 instance as a self-hosted GitHub Actions runner.** Navigate to `Settings → Actions → Runners` in your GitHub repository and follow the prompts.
+6. **Set up GitHub secrets** used by the CI/CD workflow:
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   - `AWS_REGION` (e.g., `us-east-1`)
+   - `AWS_ECR_LOGIN_URI`
+   - `ECR_REPOSITORY_NAME`

--- a/app.py
+++ b/app.py
@@ -1,45 +1,121 @@
-from fastapi import FastAPI
-import uvicorn
-import sys
-import os
-from fastapi.templating import Jinja2Templates
-from starlette.responses import RedirectResponse
-from fastapi.responses import Response
+from typing import Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.pipeline.prediction import PredictionPipeline
+from textSummarizer.service.training_jobs import TrainingJobManager
+
+app = FastAPI(title="Text Summarizer Service", version="2.0.0")
+job_manager = TrainingJobManager(max_workers=1)
 
 
-text:str = "What is Text Summarization?"
+class TrainingRequest(BaseModel):
+    dataset_id: Optional[str] = None
+    hyperparameter_search: bool = False
+    sweep_trials: Optional[int] = None
+    experiment_name: Optional[str] = None
 
-app = FastAPI()
 
-@app.get("/", tags=["authentication"])
-async def index():
+class TrainingResponse(BaseModel):
+    job_id: str
+    status: str
+
+
+class JobStatusResponse(BaseModel):
+    job_id: str
+    dataset_id: Optional[str]
+    status: str
+    submitted_at: float
+    started_at: Optional[float]
+    finished_at: Optional[float]
+    error: Optional[str]
+    experiment_name: Optional[str]
+
+
+class PredictionRequest(BaseModel):
+    text: str
+    dataset_id: Optional[str] = None
+
+
+class PredictionResponse(BaseModel):
+    dataset_id: str
+    summary: str
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    manager = ConfigurationManager()
+    PredictionPipeline.warmup(manager.dataset_id)
+
+
+@app.get("/", tags=["root"])
+async def index() -> RedirectResponse:
     return RedirectResponse(url="/docs")
 
 
+@app.get("/datasets")
+async def list_datasets() -> Dict[str, object]:
+    manager = ConfigurationManager()
+    datasets = []
+    for dataset_id in manager.available_datasets:
+        dataset_cfg = manager.config.datasets[dataset_id]
+        datasets.append(
+            {
+                "id": dataset_id,
+                "description": dataset_cfg.get("description", ""),
+                "ingestion_type": dataset_cfg.ingestion.type,
+                "input_column": dataset_cfg.columns.input_text,
+                "target_column": dataset_cfg.columns.target_text,
+                "max_input_length": int(dataset_cfg.max_input_length),
+                "max_target_length": int(dataset_cfg.max_target_length),
+            }
+        )
+    return {"default": manager.dataset_id, "datasets": datasets}
 
-@app.get("/train")
-async def training():
+
+@app.post("/train", response_model=TrainingResponse)
+async def enqueue_training(request: TrainingRequest) -> TrainingResponse:
     try:
-        os.system("python main.py")
-        return Response("Training successful !!")
+        manager = ConfigurationManager(dataset_id=request.dataset_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    job_id = job_manager.submit(
+        dataset_id=manager.dataset_id,
+        enable_hyperparameter_search=request.hyperparameter_search,
+        hyperparameter_trials=request.sweep_trials,
+        experiment_name=request.experiment_name,
+    )
+    return TrainingResponse(job_id=job_id, status="queued")
 
-    except Exception as e:
-        return Response(f"Error Occurred! {e}")
-    
 
-
-
-@app.post("/predict")
-async def predict_route(text):
+@app.get("/train/{job_id}", response_model=JobStatusResponse)
+async def training_status(job_id: str) -> JobStatusResponse:
     try:
+        job = job_manager.get(job_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found") from exc
+    return JobStatusResponse(**job)
 
-        obj = PredictionPipeline()
-        text = obj.predict(text)
-        return text
-    except Exception as e:
-        raise e
-    
 
-if __name__=="__main__":
+@app.get("/train", response_model=Dict[str, JobStatusResponse])
+async def list_jobs() -> Dict[str, JobStatusResponse]:
+    jobs = job_manager.list_jobs()
+    return {job_id: JobStatusResponse(**info) for job_id, info in jobs.items()}
+
+
+@app.post("/predict", response_model=PredictionResponse)
+async def predict(request: PredictionRequest) -> PredictionResponse:
+    if not request.text or not request.text.strip():
+        raise HTTPException(status_code=400, detail="Text is required for prediction.")
+    predictor = PredictionPipeline(dataset_id=request.dataset_id)
+    summary = predictor.predict(request.text)
+    return PredictionResponse(dataset_id=predictor.config.dataset_id, summary=summary)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,33 +1,68 @@
 artifacts_root: artifacts
-
+default_dataset: samsum
 
 data_ingestion:
   root_dir: artifacts/data_ingestion
-  source_URL: https://github.com/atharvayeola/text-summarizer/raw/main/data/summarizer-data.zip
-  local_data_file: artifacts/data_ingestion/data.zip
-  unzip_dir: artifacts/data_ingestion
-
 
 data_validation:
   root_dir: artifacts/data_validation
-  STATUS_FILE: artifacts/data_validation/status.txt
-  ALL_REQUIRED_FILES: ["train", "test", "validation"]
-
+  status_file_name: status.txt
+  required_splits: ["train", "validation", "test"]
 
 data_transformation:
   root_dir: artifacts/data_transformation
-  data_path: artifacts/data_ingestion/samsum_dataset
   tokenizer_name: google/pegasus-cnn_dailymail
 
-  
 model_trainer:
   root_dir: artifacts/model_trainer
-  data_path: artifacts/data_transformation/samsum_dataset
   model_ckpt: google/pegasus-cnn_dailymail
 
 model_evaluation:
   root_dir: artifacts/model_evaluation
-  data_path: artifacts/data_transformation/samsum_dataset
-  model_path: artifacts/model_trainer/pegasus-samsum-model
-  tokenizer_path: artifacts/model_trainer/tokenizer
-  metric_file_name: artifacts/model_evaluation/metrics.csv
+  generation:
+    length_penalty: 0.8
+    num_beams: 8
+    max_length: 128
+    min_length: 12
+  metrics:
+    sample_size: 50
+    names: ["rouge1", "rouge2", "rougeL", "rougeLsum"]
+
+experiment_tracking:
+  root_dir: artifacts/experiments
+
+datasets:
+  samsum:
+    description: "Dialogues summarization dataset from Samsum."
+    ingestion:
+      type: zip
+      source_url: https://github.com/atharvayeola/text-summarizer/raw/main/data/summarizer-data.zip
+      archive_filename: samsum.zip
+      extracted_folder_name: samsum_dataset
+    columns:
+      input_text: dialogue
+      target_text: summary
+    splits:
+      train: train
+      validation: validation
+      test: test
+    max_input_length: 1024
+    max_target_length: 128
+    preprocessing_fn:
+
+  cnn_dailymail:
+    description: "News summarization dataset from CNN/DailyMail (via Hugging Face)."
+    ingestion:
+      type: huggingface
+      dataset_name: cnn_dailymail
+      subset: 3.0.0
+    columns:
+      input_text: article
+      target_text: highlights
+    splits:
+      train: train
+      validation: validation
+      test: test
+    max_input_length: 1024
+    max_target_length: 128
+    preprocessing_fn:

--- a/main.py
+++ b/main.py
@@ -1,59 +1,47 @@
-from textSummarizer.pipeline.stage1_data_ingestion import DataIngestionTrainingPipeline
-from textSummarizer.pipeline.stage2_data_validation import DataValidationTrainingPipeline
-from textSummarizer.pipeline.stage3_data_transformation import DataTransformationTrainingPipeline
-from textSummarizer.pipeline.stage4_model_trainer import ModelTrainerTrainingPipeline
-from textSummarizer.pipeline.stage5_model_evaluation import ModelEvaluationTrainingPipeline
+import argparse
+
 from textSummarizer.logging import logger
-
-STAGE_NAME = "Data Ingestion stage"
-try:
-   logger.info(f">>>>>> stage {STAGE_NAME} started <<<<<<") 
-   data_ingestion = DataIngestionTrainingPipeline()
-   data_ingestion.main()
-   logger.info(f">>>>>> stage {STAGE_NAME} completed <<<<<<\n\nx==========x")
-except Exception as e:
-        logger.exception(e)
-        raise e
+from textSummarizer.pipeline.training import run_training_pipeline
 
 
-STAGE_NAME = "Data Validation stage"
-try:
-   logger.info(f">>>>>> stage {STAGE_NAME} started <<<<<<") 
-   data_validation = DataValidationTrainingPipeline()
-   data_validation.main()
-   logger.info(f">>>>>> stage {STAGE_NAME} completed <<<<<<\n\nx==========x")
-except Exception as e:
-        logger.exception(e)
-        raise e
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the text summarization training pipeline.")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Dataset identifier defined in config/config.yaml (defaults to config.default_dataset).",
+    )
+    parser.add_argument(
+        "--hyperparameter-search",
+        action="store_true",
+        help="Enable hyperparameter search using the configured backend.",
+    )
+    parser.add_argument(
+        "--sweep-trials",
+        type=int,
+        default=None,
+        help="Override the number of hyperparameter search trials.",
+    )
+    parser.add_argument(
+        "--experiment-name",
+        type=str,
+        default=None,
+        help="Optional experiment/run name used for tracking artifacts.",
+    )
+    return parser.parse_args()
 
-STAGE_NAME = "Data Transformation stage"
-try:
-   logger.info(f">>>>>> stage {STAGE_NAME} started <<<<<<") 
-   data_transformation = DataTransformationTrainingPipeline()
-   data_transformation.main()
-   logger.info(f">>>>>> stage {STAGE_NAME} completed <<<<<<\n\nx==========x")
-except Exception as e:
-        logger.exception(e)
-        raise e
 
-STAGE_NAME = "Model Trainer stage"
-try: 
-   logger.info(f"*******************")
-   logger.info(f">>>>>> stage {STAGE_NAME} started <<<<<<")
-   model_trainer = ModelTrainerTrainingPipeline()
-   model_trainer.main()
-   logger.info(f">>>>>> stage {STAGE_NAME} completed <<<<<<\n\nx==========x")
-except Exception as e:
-        logger.exception(e)
-        raise e
+def main() -> None:
+    args = parse_args()
+    logger.info("CLI arguments: %s", args)
+    run_training_pipeline(
+        dataset_id=args.dataset,
+        enable_hyperparameter_search=args.hyperparameter_search,
+        hyperparameter_trials=args.sweep_trials,
+        experiment_name=args.experiment_name,
+    )
 
-STAGE_NAME = "Model Evaluation stage"
-try: 
-   logger.info(f"*******************")
-   logger.info(f">>>>>> stage {STAGE_NAME} started <<<<<<")
-   model_evaluation = ModelEvaluationTrainingPipeline()
-   model_evaluation.main()
-   logger.info(f">>>>>> stage {STAGE_NAME} completed <<<<<<\n\nx==========x")
-except Exception as e:
-        logger.exception(e)
-        raise e
+
+if __name__ == "__main__":
+    main()

--- a/params.yaml
+++ b/params.yaml
@@ -1,10 +1,43 @@
-TrainingArguments:
-  num_train_epochs: 1
-  warmup_steps: 500
-  per_device_train_batch_size: 5
-  weight_decay: 0.01
-  logging_steps: 10
-  evaluation_strategy: steps
-  eval_steps: 500
-  save_steps: 1e6
-  gradient_accumulation_steps: 16
+training:
+  arguments:
+    num_train_epochs: 1
+    warmup_steps: 500
+    per_device_train_batch_size: 2
+    per_device_eval_batch_size: 2
+    weight_decay: 0.01
+    logging_steps: 10
+    evaluation_strategy: steps
+    eval_steps: 500
+    save_steps: 1000
+    gradient_accumulation_steps: 8
+    learning_rate: 5.0e-5
+    report_to:
+      - none
+    predict_with_generate: true
+  hyperparameter_search:
+    enabled: false
+    backend: optuna
+    direction: minimize
+    n_trials: 10
+    params:
+      learning_rate:
+        distribution: float
+        low: 1.0e-5
+        high: 5.0e-4
+        log: true
+      per_device_train_batch_size:
+        distribution: categorical
+        values: [2, 4, 8]
+      num_train_epochs:
+        distribution: int
+        low: 1
+        high: 3
+        step: 1
+experiment_tracking:
+  enabled: false
+  backend: local
+  project: text-summarizer
+  entity:
+  run_name:
+  tags: []
+  mode: offline

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ ensure==1.0.2
 fastapi==0.78.0
 uvicorn==0.18.3
 Jinja2==3.1.2
+optuna>=3.0.0
 -e .

--- a/src/textSummarizer/components/data_ingestion.py
+++ b/src/textSummarizer/components/data_ingestion.py
@@ -1,36 +1,74 @@
-import os
 import urllib.request as request
 import zipfile
+from pathlib import Path
+
+from datasets import load_dataset
+
+from textSummarizer.entity import DataIngestionConfig
 from textSummarizer.logging import logger
 from textSummarizer.utils.common import get_size
-from textSummarizer.entity import DataIngestionConfig
-from pathlib import Path
+
 
 class DataIngestion:
     def __init__(self, config: DataIngestionConfig):
         self.config = config
 
+    def _download_zip(self) -> None:
+        if not self.config.source_url or not self.config.local_data_file:
+            raise ValueError("Zip ingestion requires a source_url and local_data_file path.")
+        local_path = Path(self.config.local_data_file)
+        if local_path.exists():
+            logger.info("Dataset archive already exists: %s (size: %s)", local_path, get_size(local_path))
+            return
+        logger.info("Downloading dataset from %s", self.config.source_url)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        request.urlretrieve(url=self.config.source_url, filename=local_path)
+        logger.info("Download complete: %s (size: %s)", local_path, get_size(local_path))
 
-    
-    def download_file(self):
-        if not os.path.exists(self.config.local_data_file):
-            filename, headers = request.urlretrieve(
-                url = self.config.source_URL,
-                filename = self.config.local_data_file
-            )
-            logger.info(f"{filename} download! with following info: \n{headers}")
+    def _extract_zip(self) -> None:
+        if not self.config.local_data_file:
+            raise ValueError("Zip ingestion requires a local_data_file path.")
+        dataset_path = Path(self.config.dataset_path)
+        if dataset_path.exists():
+            logger.info("Extracted dataset already available at %s", dataset_path)
+            return
+        archive_path = Path(self.config.local_data_file)
+        if not archive_path.exists():
+            raise FileNotFoundError(f"Archive not found at {archive_path}. Download it before extraction.")
+        logger.info("Extracting archive %s to %s", archive_path, self.config.raw_data_dir)
+        with zipfile.ZipFile(archive_path, "r") as zip_ref:
+            zip_ref.extractall(self.config.raw_data_dir)
+        logger.info("Extraction complete. Dataset available at %s", dataset_path)
+
+    def _ingest_zip_dataset(self) -> None:
+        dataset_path = Path(self.config.dataset_path)
+        if dataset_path.exists():
+            logger.info("Dataset already prepared at %s", dataset_path)
+            return
+        self._download_zip()
+        self._extract_zip()
+
+    def _ingest_huggingface_dataset(self) -> None:
+        if not self.config.huggingface_dataset:
+            raise ValueError("Hugging Face ingestion requires a dataset name.")
+        dataset_path = Path(self.config.dataset_path)
+        if dataset_path.exists():
+            logger.info("Hugging Face dataset already cached at %s", dataset_path)
+            return
+        logger.info(
+            "Downloading Hugging Face dataset %s (subset=%s)",
+            self.config.huggingface_dataset,
+            self.config.huggingface_subset,
+        )
+        dataset = load_dataset(self.config.huggingface_dataset, self.config.huggingface_subset)
+        dataset.save_to_disk(dataset_path)
+        logger.info("Saved Hugging Face dataset to %s", dataset_path)
+
+    def run(self) -> None:
+        if self.config.ingestion_type == "zip":
+            self._ingest_zip_dataset()
+        elif self.config.ingestion_type == "huggingface":
+            self._ingest_huggingface_dataset()
         else:
-            logger.info(f"File already exists of size: {get_size(Path(self.config.local_data_file))}")  
-
-        
-    
-    def extract_zip_file(self):
-        """
-        zip_file_path: str
-        Extracts the zip file into the data directory
-        Function returns None
-        """
-        unzip_path = self.config.unzip_dir
-        os.makedirs(unzip_path, exist_ok=True)
-        with zipfile.ZipFile(self.config.local_data_file, 'r') as zip_ref:
-            zip_ref.extractall(unzip_path)
+            raise ValueError(f"Unsupported ingestion type '{self.config.ingestion_type}'.")
+        logger.info("Data ingestion complete for dataset '%s'", self.config.dataset_id)

--- a/src/textSummarizer/components/data_transformation.py
+++ b/src/textSummarizer/components/data_transformation.py
@@ -1,33 +1,49 @@
-import os
-from textSummarizer.logging import logger
-from transformers import AutoTokenizer
-from datasets import load_dataset, load_from_disk
-from textSummarizer.entity import DataTransformationConfig
+from typing import Callable, Optional
 
+from datasets import load_from_disk
+from transformers import AutoTokenizer
+
+from textSummarizer.entity import DataTransformationConfig
+from textSummarizer.logging import logger
+from textSummarizer.utils.common import import_from_string
 
 
 class DataTransformation:
     def __init__(self, config: DataTransformationConfig):
         self.config = config
         self.tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_name)
+        self._preprocess_fn: Optional[Callable] = None
+        if config.preprocessing_fn:
+            try:
+                self._preprocess_fn = import_from_string(config.preprocessing_fn)
+                logger.info("Loaded custom preprocessing function '%s'", config.preprocessing_fn)
+            except ImportError as exc:
+                logger.warning("Unable to import preprocessing function '%s': %s", config.preprocessing_fn, exc)
 
+    def _tokenize_batch(self, example_batch):
+        inputs = example_batch[self.config.input_column]
+        targets = example_batch[self.config.target_column]
+        model_inputs = self.tokenizer(
+            inputs,
+            max_length=self.config.max_input_length,
+            truncation=True,
+            padding="max_length",
+        )
+        labels = self.tokenizer(
+            text_target=targets,
+            max_length=self.config.max_target_length,
+            truncation=True,
+            padding="max_length",
+        )
+        model_inputs["labels"] = labels["input_ids"]
+        return model_inputs
 
-    
-    def convert_examples_to_features(self,example_batch):
-        input_encodings = self.tokenizer(example_batch['dialogue'] , max_length = 1024, truncation = True )
-        
-        with self.tokenizer.as_target_tokenizer():
-            target_encodings = self.tokenizer(example_batch['summary'], max_length = 128, truncation = True )
-            
-        return {
-            'input_ids' : input_encodings['input_ids'],
-            'attention_mask': input_encodings['attention_mask'],
-            'labels': target_encodings['input_ids']
-        }
-    
-
-    def convert(self):
-        dataset_samsum = load_from_disk(self.config.data_path)
-        dataset_samsum_pt = dataset_samsum.map(self.convert_examples_to_features, batched = True)
-        dataset_samsum_pt.save_to_disk(os.path.join(self.config.root_dir,"samsum_dataset"))
-
+    def convert(self) -> None:
+        dataset = load_from_disk(self.config.data_path)
+        if self._preprocess_fn:
+            logger.info("Applying custom preprocessing function before tokenization")
+            dataset = dataset.map(self._preprocess_fn)
+        logger.info("Tokenizing dataset for columns '%s' -> '%s'", self.config.input_column, self.config.target_column)
+        tokenized_dataset = dataset.map(self._tokenize_batch, batched=True, remove_columns=None)
+        tokenized_dataset.save_to_disk(self.config.transformed_data_path)
+        logger.info("Saved tokenized dataset to %s", self.config.transformed_data_path)

--- a/src/textSummarizer/components/data_validation.py
+++ b/src/textSummarizer/components/data_validation.py
@@ -1,30 +1,32 @@
-import os
-from textSummarizer.logging import logger
+from pathlib import Path
+from typing import List
+
 from textSummarizer.entity import DataValidationConfig
+from textSummarizer.logging import logger
+
 
 class DataValidation:
     def __init__(self, config: DataValidationConfig):
         self.config = config
 
+    def _record_status(self, status: bool, missing: List[str]) -> None:
+        status_message = f"Validation status: {status}"
+        if missing:
+            status_message += f" | missing splits: {', '.join(missing)}"
+        self.config.status_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.config.status_file, "w", encoding="utf-8") as file:
+            file.write(status_message)
+        logger.info(status_message)
 
-    
-    def validate_all_files_exist(self)-> bool:
-        try:
-            validation_status = None
-
-            all_files = os.listdir(os.path.join("artifacts","data_ingestion","samsum_dataset"))
-
-            for file in all_files:
-                if file not in self.config.ALL_REQUIRED_FILES:
-                    validation_status = False
-                    with open(self.config.STATUS_FILE, 'w') as f:
-                        f.write(f"Validation status: {validation_status}")
-                else:
-                    validation_status = True
-                    with open(self.config.STATUS_FILE, 'w') as f:
-                        f.write(f"Validation status: {validation_status}")
-
-            return validation_status
-        
-        except Exception as e:
-            raise e
+    def validate_all_files_exist(self) -> bool:
+        dataset_root = Path(self.config.data_path)
+        missing_splits: List[str] = []
+        for required_split in self.config.required_splits:
+            split_name = self.config.splits.get(required_split, required_split)
+            split_path = dataset_root / split_name
+            if not split_path.exists():
+                logger.warning("Missing expected split '%s' at %s", split_name, split_path)
+                missing_splits.append(split_name)
+        status = not missing_splits
+        self._record_status(status, missing_splits)
+        return status

--- a/src/textSummarizer/components/model_evaluation.py
+++ b/src/textSummarizer/components/model_evaluation.py
@@ -1,80 +1,116 @@
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-from datasets import load_dataset, load_from_disk, load_metric
-import torch
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
 import pandas as pd
+import torch
+from datasets import load_from_disk, load_metric
 from tqdm import tqdm
-from textSummarizer.entity import ModelEvaluationConfig
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
-
+from textSummarizer.entity import ExperimentTrackingConfig, ModelEvaluationConfig
+from textSummarizer.logging import logger
+from textSummarizer.utils.tracking import ExperimentTracker
 
 
 class ModelEvaluation:
-    def __init__(self, config: ModelEvaluationConfig):
+    def __init__(self, config: ModelEvaluationConfig, tracking_config: Optional[ExperimentTrackingConfig] = None):
         self.config = config
+        self.tracker = ExperimentTracker(tracking_config) if tracking_config else ExperimentTracker(
+            ExperimentTrackingConfig(
+                enabled=False,
+                backend="local",
+                project=None,
+                entity=None,
+                run_name="evaluation",
+                tags=(),
+                mode=None,
+                root_dir=config.root_dir,
+                dataset_id=config.dataset_id,
+            )
+        )
 
+    def _generate_batches(self, items, batch_size: int):
+        for index in range(0, len(items), batch_size):
+            yield items[index : index + batch_size]
 
-    
-    def generate_batch_sized_chunks(self,list_of_elements, batch_size):
-        """split the dataset into smaller batches that we can process simultaneously
-        Yield successive batch-sized chunks from list_of_elements."""
-        for i in range(0, len(list_of_elements), batch_size):
-            yield list_of_elements[i : i + batch_size]
+    def _calculate_metrics(
+        self,
+        dataset_split,
+        model,
+        tokenizer,
+        batch_size: int = 8,
+    ) -> Dict[str, float]:
+        metric = load_metric("rouge")
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model.to(device)
+        input_column = self.config.input_column
+        target_column = self.config.target_column
+        generation_kwargs = dict(self.config.generation_kwargs)
 
-    
-    def calculate_metric_on_test_ds(self,dataset, metric, model, tokenizer, 
-                               batch_size=16, device="cuda" if torch.cuda.is_available() else "cpu", 
-                               column_text="article", 
-                               column_summary="highlights"):
-        article_batches = list(self.generate_batch_sized_chunks(dataset[column_text], batch_size))
-        target_batches = list(self.generate_batch_sized_chunks(dataset[column_summary], batch_size))
+        article_batches = list(self._generate_batches(dataset_split[input_column], batch_size))
+        target_batches = list(self._generate_batches(dataset_split[target_column], batch_size))
 
         for article_batch, target_batch in tqdm(
-            zip(article_batches, target_batches), total=len(article_batches)):
-            
-            inputs = tokenizer(article_batch, max_length=1024,  truncation=True, 
-                            padding="max_length", return_tensors="pt")
-            
-            summaries = model.generate(input_ids=inputs["input_ids"].to(device),
-                            attention_mask=inputs["attention_mask"].to(device), 
-                            length_penalty=0.8, num_beams=8, max_length=128)
-            ''' parameter for length penalty ensures that the model does not generate sequences that are too long. '''
-            
-            # Finally, we decode the generated texts, 
-            # replace the  token, and add the decoded texts with the references to the metric.
-            decoded_summaries = [tokenizer.decode(s, skip_special_tokens=True, 
-                                    clean_up_tokenization_spaces=True) 
-                for s in summaries]      
-            
-            decoded_summaries = [d.replace("", " ") for d in decoded_summaries]
-            
-            
-            metric.add_batch(predictions=decoded_summaries, references=target_batch)
-            
-        #  Finally compute and return the ROUGE scores.
-        score = metric.compute()
-        return score
-
-
-    def evaluate(self):
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        tokenizer = AutoTokenizer.from_pretrained(self.config.tokenizer_path)
-        model_pegasus = AutoModelForSeq2SeqLM.from_pretrained(self.config.model_path).to(device)
-       
-        #loading data 
-        dataset_samsum_pt = load_from_disk(self.config.data_path)
-
-
-        rouge_names = ["rouge1", "rouge2", "rougeL", "rougeLsum"]
-  
-        rouge_metric = load_metric('rouge')
-
-        score = self.calculate_metric_on_test_ds(
-        dataset_samsum_pt['test'][0:10], rouge_metric, model_pegasus, tokenizer, batch_size = 2, column_text = 'dialogue', column_summary= 'summary'
+            zip(article_batches, target_batches),
+            total=len(article_batches),
+            desc="Evaluating",
+        ):
+            inputs = tokenizer(
+                article_batch,
+                max_length=self.config.input_max_length,
+                truncation=True,
+                padding="max_length",
+                return_tensors="pt",
             )
+            summaries = model.generate(
+                input_ids=inputs["input_ids"].to(device),
+                attention_mask=inputs["attention_mask"].to(device),
+                **generation_kwargs,
+            )
+            decoded = [
+                tokenizer.decode(summary, skip_special_tokens=True, clean_up_tokenization_spaces=True)
+                for summary in summaries
+            ]
+            metric.add_batch(predictions=decoded, references=target_batch)
 
-        rouge_dict = dict((rn, score[rn].mid.fmeasure ) for rn in rouge_names )
+        scores = metric.compute()
+        rouge_scores = {}
+        for name in self.config.metric_names:
+            score = scores[name]
+            rouge_scores[name] = score.mid.fmeasure if hasattr(score, "mid") else score
+        return rouge_scores
 
-        df = pd.DataFrame(rouge_dict, index = ['pegasus'] )
-        df.to_csv(self.config.metric_file_name, index=False)
+    def evaluate(self, batch_size: int = 8) -> Dict[str, float]:
+        logger.info("Starting model evaluation for dataset '%s'", self.config.dataset_id)
+        tokenizer = AutoTokenizer.from_pretrained(self.config.tokenizer_path)
+        model = AutoModelForSeq2SeqLM.from_pretrained(self.config.model_path)
+        dataset = load_from_disk(self.config.data_path)
+        test_split = dataset[self.config.splits.get("test", "test")]
+        if self.config.sample_size:
+            limit = min(int(self.config.sample_size), len(test_split))
+            logger.info("Subsampling evaluation dataset to %s examples", limit)
+            test_split = test_split.select(range(limit))
 
-        
+        self.tracker.start_run({
+            "dataset_id": self.config.dataset_id,
+            "model_path": str(self.config.model_path),
+        })
+        self.tracker.log_params({
+            "evaluation_sample_size": len(test_split),
+            "generation_kwargs": self.config.generation_kwargs,
+        })
+
+        try:
+            rouge_scores = self._calculate_metrics(test_split, model, tokenizer, batch_size=batch_size)
+            metrics_path = Path(self.config.metric_file_name)
+            metrics_path.parent.mkdir(parents=True, exist_ok=True)
+            df = pd.DataFrame([rouge_scores])
+            df.to_csv(metrics_path, index=False)
+            with open(metrics_path.with_suffix(".json"), "w", encoding="utf-8") as file:
+                json.dump({"dataset_id": self.config.dataset_id, "metrics": rouge_scores}, file, indent=2)
+            logger.info("Evaluation metrics written to %s", metrics_path)
+            self.tracker.log_metrics({f"evaluation/{k}": v for k, v in rouge_scores.items()})
+            return rouge_scores
+        finally:
+            self.tracker.finish()

--- a/src/textSummarizer/components/model_trainer.py
+++ b/src/textSummarizer/components/model_trainer.py
@@ -1,52 +1,131 @@
-from transformers import TrainingArguments, Trainer
-from transformers import DataCollatorForSeq2Seq
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-from datasets import load_dataset, load_from_disk
-from textSummarizer.entity import ModelTrainerConfig
-import torch
-import os
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+from datasets import load_from_disk
+from transformers import (
+    AutoModelForSeq2SeqLM,
+    AutoTokenizer,
+    DataCollatorForSeq2Seq,
+    Trainer,
+    TrainingArguments,
+)
+
+from textSummarizer.entity import ExperimentTrackingConfig, ModelTrainerConfig
+from textSummarizer.logging import logger
+from textSummarizer.utils.tracking import ExperimentTracker, ExperimentTrackerCallback
 
 
 class ModelTrainer:
-    def __init__(self, config: ModelTrainerConfig):
+    def __init__(self, config: ModelTrainerConfig, tracking_config: ExperimentTrackingConfig):
         self.config = config
+        self.tracker = ExperimentTracker(tracking_config)
+        self._tokenizer = AutoTokenizer.from_pretrained(config.model_ckpt)
+        self._data_collator = DataCollatorForSeq2Seq(self._tokenizer)
 
+    def _model_init(self):
+        return AutoModelForSeq2SeqLM.from_pretrained(self.config.model_ckpt)
 
-    
-    def train(self):
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        tokenizer = AutoTokenizer.from_pretrained(self.config.model_ckpt)
-        model_pegasus = AutoModelForSeq2SeqLM.from_pretrained(self.config.model_ckpt).to(device)
-        seq2seq_data_collator = DataCollatorForSeq2Seq(tokenizer, model=model_pegasus)
-        
-        #loading data 
-        dataset_samsum_pt = load_from_disk(self.config.data_path)
+    def _build_trainer(self, training_args: Dict, train_dataset, eval_dataset) -> Trainer:
+        args = TrainingArguments(**training_args)
+        callbacks = [ExperimentTrackerCallback(self.tracker)] if self.tracker.enabled else []
+        return Trainer(
+            args=args,
+            tokenizer=self._tokenizer,
+            data_collator=self._data_collator,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            model_init=self._model_init,
+            callbacks=callbacks,
+        )
 
-        # trainer_args = TrainingArguments(
-        #     output_dir=self.config.root_dir, num_train_epochs=self.config.num_train_epochs, warmup_steps=self.config.warmup_steps,
-        #     per_device_train_batch_size=self.config.per_device_train_batch_size, per_device_eval_batch_size=self.config.per_device_train_batch_size,
-        #     weight_decay=self.config.weight_decay, logging_steps=self.config.logging_steps,
-        #     evaluation_strategy=self.config.evaluation_strategy, eval_steps=self.config.eval_steps, save_steps=1e6,
-        #     gradient_accumulation_steps=self.config.gradient_accumulation_steps
-        # ) 
+    def _run_hyperparameter_search(self, trainer: Trainer) -> Optional[Dict[str, float]]:
+        hp_config = self.config.hyperparameter_search
+        if not hp_config.enabled or hp_config.n_trials <= 0 or not hp_config.params:
+            return None
 
+        logger.info(
+            "Starting hyperparameter search (%s trials, direction=%s)",
+            hp_config.n_trials,
+            hp_config.direction,
+        )
 
-        trainer_args = TrainingArguments(
-            output_dir=self.config.root_dir, num_train_epochs=1, warmup_steps=500,
-            per_device_train_batch_size=1, per_device_eval_batch_size=1,
-            weight_decay=0.01, logging_steps=10,
-            evaluation_strategy='steps', eval_steps=500, save_steps=1e6,
-            gradient_accumulation_steps=16
-        ) 
+        def hp_space(trial):  # type: ignore[override]
+            space = {}
+            for name, spec in hp_config.params.items():
+                distribution = str(spec.get("distribution", "float")).lower()
+                if distribution == "float":
+                    space[name] = trial.suggest_float(
+                        name,
+                        float(spec["low"]),
+                        float(spec["high"]),
+                        log=bool(spec.get("log", False)),
+                    )
+                elif distribution == "int":
+                    space[name] = trial.suggest_int(
+                        name,
+                        int(spec["low"]),
+                        int(spec["high"]),
+                        step=int(spec.get("step", 1)),
+                        log=bool(spec.get("log", False)),
+                    )
+                elif distribution == "categorical":
+                    space[name] = trial.suggest_categorical(name, list(spec.get("values", [])))
+                else:
+                    raise ValueError(f"Unsupported distribution '{distribution}' for hyperparameter '{name}'")
+            return space
 
-        trainer = Trainer(model=model_pegasus, args=trainer_args,
-                  tokenizer=tokenizer, data_collator=seq2seq_data_collator,
-                  train_dataset=dataset_samsum_pt["train"], 
-                  eval_dataset=dataset_samsum_pt["validation"])
-        
-        trainer.train()
+        best_run = trainer.hyperparameter_search(
+            direction=hp_config.direction,
+            n_trials=hp_config.n_trials,
+            hp_space=hp_space,
+        )
+        best_params = dict(best_run.hyperparameters)
+        logger.info("Best hyperparameters: %s (objective=%.4f)", best_params, best_run.objective)
+        self.tracker.log_params({f"best_{k}": v for k, v in best_params.items()})
+        search_summary = {
+            "best_params": best_params,
+            "objective": best_run.objective,
+            "direction": hp_config.direction,
+        }
+        with open(Path(self.config.run_dir) / "hyperparameter_search.json", "w", encoding="utf-8") as file:
+            json.dump(search_summary, file, indent=2)
+        return best_params
 
-        ## Save model
-        model_pegasus.save_pretrained(os.path.join(self.config.root_dir,"pegasus-samsum-model"))
-        ## Save tokenizer
-        tokenizer.save_pretrained(os.path.join(self.config.root_dir,"tokenizer"))
+    def train(self) -> None:
+        training_args = dict(self.config.training_args)
+        dataset = load_from_disk(self.config.data_path)
+        train_dataset = dataset[self.config.train_split]
+        eval_dataset = dataset[self.config.eval_split]
+        run_metadata = {
+            "dataset_id": self.config.dataset_id,
+            "model_ckpt": self.config.model_ckpt,
+            "train_split": self.config.train_split,
+            "eval_split": self.config.eval_split,
+        }
+        self.tracker.start_run(run_metadata)
+        self.tracker.log_params({"initial_training_args": training_args})
+
+        trainer = self._build_trainer(training_args, train_dataset, eval_dataset)
+        best_params: Optional[Dict[str, float]] = None
+        try:
+            best_params = self._run_hyperparameter_search(trainer)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Hyperparameter search failed: %s", exc)
+        if best_params:
+            logger.info("Rebuilding trainer with best hyperparameters")
+            training_args.update(best_params)
+            self.tracker.log_params({"final_training_args": training_args})
+            trainer = self._build_trainer(training_args, train_dataset, eval_dataset)
+        else:
+            self.tracker.log_params({"final_training_args": training_args})
+
+        try:
+            trainer.train()
+            trainer.save_model(self.config.model_dir)
+            self._tokenizer.save_pretrained(self.config.tokenizer_dir)
+            with open(Path(self.config.run_dir) / "training_args.json", "w", encoding="utf-8") as file:
+                json.dump(training_args, file, indent=2)
+            logger.info("Model saved to %s", self.config.model_dir)
+        finally:
+            self.tracker.finish()

--- a/src/textSummarizer/config/configuration.py
+++ b/src/textSummarizer/config/configuration.py
@@ -1,94 +1,275 @@
-from textSummarizer.constants import *
-from textSummarizer.utils.common import read_yaml, create_directories
-from textSummarizer.entity import (DataIngestionConfig, DataValidationConfig,DataTransformationConfig,
-                                   ModelTrainerConfig,
-                                   ModelEvaluationConfig)
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from textSummarizer.constants import CONFIG_FILE_PATH, PARAMS_FILE_PATH
+from textSummarizer.entity import (
+    DataIngestionConfig,
+    DataTransformationConfig,
+    DataValidationConfig,
+    ExperimentTrackingConfig,
+    HyperparameterSearchConfig,
+    ModelEvaluationConfig,
+    ModelTrainerConfig,
+)
+from textSummarizer.utils.common import create_directories, read_yaml
+
+
 class ConfigurationManager:
-    def __init__ (
-            self,
-            config_filepath = CONFIG_FILE_PATH,
-            params_filepath = PARAMS_FILE_PATH):
+    """Hydrates strongly typed configuration objects for each pipeline stage."""
 
-            self.config = read_yaml(config_filepath)
-            self.params = read_yaml(params_filepath)
+    def __init__(
+        self,
+        config_filepath: Path = CONFIG_FILE_PATH,
+        params_filepath: Path = PARAMS_FILE_PATH,
+        dataset_id: Optional[str] = None,
+    ) -> None:
+        self.config = read_yaml(config_filepath)
+        self.params = read_yaml(params_filepath)
 
-            create_directories([self.config.artifacts_root])
+        create_directories([self.config.artifacts_root])
+
+        self._available_datasets = list(self.config.datasets.keys())
+        self.dataset_id = dataset_id or self.config.get("default_dataset")
+        if not self.dataset_id:
+            raise ValueError("Dataset identifier is required. Set default_dataset in the config or pass dataset_id explicitly.")
+        if self.dataset_id not in self.config.datasets:
+            raise ValueError(
+                f"Dataset '{self.dataset_id}' is not defined in config/config.yaml. Available options: {', '.join(self._available_datasets)}"
+            )
+        self.dataset_config = self.config.datasets[self.dataset_id]
+
+        self._data_ingestion_config: Optional[DataIngestionConfig] = None
+        self._data_validation_config: Optional[DataValidationConfig] = None
+        self._data_transformation_config: Optional[DataTransformationConfig] = None
+        self._model_trainer_config: Optional[ModelTrainerConfig] = None
+        self._model_evaluation_config: Optional[ModelEvaluationConfig] = None
+
+    @property
+    def available_datasets(self) -> List[str]:
+        return list(self._available_datasets)
+
+    def _stage_root(self, stage_root: str) -> Path:
+        root = Path(stage_root) / self.dataset_id
+        create_directories([root])
+        return root
+
+    def _raw_dataset_path(self) -> Path:
+        ingestion_cfg = self.dataset_config.ingestion
+        stage_root = self._stage_root(self.config.data_ingestion.root_dir)
+        raw_root = stage_root / "raw"
+        create_directories([raw_root])
+        if ingestion_cfg.type.lower() == "zip":
+            extracted = ingestion_cfg.get("extracted_folder_name")
+            if extracted:
+                return raw_root / extracted
+        return raw_root
 
     def get_data_ingestion_config(self) -> DataIngestionConfig:
-        config = self.config.data_ingestion
+        if self._data_ingestion_config:
+            return self._data_ingestion_config
 
-        create_directories([config.root_dir])
+        ingestion_root = self._stage_root(self.config.data_ingestion.root_dir)
+        download_dir = ingestion_root / "downloads"
+        raw_root = ingestion_root / "raw"
+        create_directories([download_dir, raw_root])
 
-        data_ingestion_config = DataIngestionConfig(
-            root_dir=config.root_dir,
-            source_URL=config.source_URL,
-            local_data_file=config.local_data_file,
-            unzip_dir=config.unzip_dir 
+        dataset_path = self._raw_dataset_path()
+        create_directories([dataset_path.parent])
+
+        ingestion_cfg = self.dataset_config.ingestion
+        ingestion_type = ingestion_cfg.type.lower()
+
+        local_data_file = None
+        if ingestion_type == "zip":
+            archive_filename = ingestion_cfg.get("archive_filename") or f"{self.dataset_id}.zip"
+            local_data_file = download_dir / archive_filename
+        elif ingestion_type == "huggingface":
+            archive_filename = None
+        else:
+            raise ValueError(f"Unsupported ingestion type '{ingestion_type}' for dataset '{self.dataset_id}'.")
+
+        config = DataIngestionConfig(
+            dataset_id=self.dataset_id,
+            root_dir=ingestion_root,
+            ingestion_type=ingestion_type,
+            download_dir=download_dir,
+            raw_data_dir=raw_root,
+            dataset_path=dataset_path,
+            source_url=ingestion_cfg.get("source_url"),
+            local_data_file=local_data_file,
+            extracted_folder_name=ingestion_cfg.get("extracted_folder_name"),
+            huggingface_dataset=ingestion_cfg.get("dataset_name"),
+            huggingface_subset=ingestion_cfg.get("subset"),
         )
+        self._data_ingestion_config = config
+        return config
 
-        return data_ingestion_config
-    
     def get_data_validation_config(self) -> DataValidationConfig:
-        config = self.config.data_validation
+        if self._data_validation_config:
+            return self._data_validation_config
 
-        create_directories([config.root_dir])
+        validation_root = self._stage_root(self.config.data_validation.root_dir)
+        status_file = validation_root / self.config.data_validation.status_file_name
+        data_path = self.get_data_ingestion_config().dataset_path
+        required_splits = list(self.config.data_validation.required_splits)
+        splits = dict(self.dataset_config.splits)
 
-        data_validation_config = DataValidationConfig(
-            root_dir=config.root_dir,
-            STATUS_FILE=config.STATUS_FILE,
-            ALL_REQUIRED_FILES=config.ALL_REQUIRED_FILES,
+        config = DataValidationConfig(
+            dataset_id=self.dataset_id,
+            root_dir=validation_root,
+            data_path=data_path,
+            required_splits=required_splits,
+            splits=splits,
+            status_file=status_file,
         )
+        self._data_validation_config = config
+        return config
 
-        return data_validation_config
-    
     def get_data_transformation_config(self) -> DataTransformationConfig:
-        config = self.config.data_transformation
+        if self._data_transformation_config:
+            return self._data_transformation_config
 
-        create_directories([config.root_dir])
+        transformation_root = self._stage_root(self.config.data_transformation.root_dir)
+        transformed_path = transformation_root / "tokenized"
+        create_directories([transformation_root])
 
-        data_transformation_config = DataTransformationConfig(
-            root_dir=config.root_dir,
-            data_path=config.data_path,
-            tokenizer_name = config.tokenizer_name
+        dataset_meta = self.dataset_config
+        config = DataTransformationConfig(
+            dataset_id=self.dataset_id,
+            root_dir=transformation_root,
+            data_path=self.get_data_ingestion_config().dataset_path,
+            tokenizer_name=self.config.data_transformation.tokenizer_name,
+            input_column=dataset_meta.columns.input_text,
+            target_column=dataset_meta.columns.target_text,
+            max_input_length=int(dataset_meta.max_input_length),
+            max_target_length=int(dataset_meta.max_target_length),
+            transformed_data_path=transformed_path,
+            preprocessing_fn=dataset_meta.get("preprocessing_fn"),
+        )
+        self._data_transformation_config = config
+        return config
+
+    def get_experiment_tracking_config(
+        self,
+        run_name_override: Optional[str] = None,
+        stage: str = "train",
+    ) -> ExperimentTrackingConfig:
+        tracking_root = self._stage_root(self.config.experiment_tracking.root_dir)
+        params = self.params.get("experiment_tracking", {})
+        enabled = bool(params.get("enabled", False))
+        backend = params.get("backend", "local")
+        project = params.get("project")
+        entity = params.get("entity")
+        configured_run_name = params.get("run_name")
+        tags = tuple(params.get("tags", []))
+        mode = params.get("mode")
+
+        base_name = run_name_override or configured_run_name
+        if base_name:
+            run_name = f"{base_name}-{stage}" if stage and not base_name.endswith(stage) else base_name
+        else:
+            timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+            run_name = f"{self.dataset_id}-{stage}-{timestamp}"
+
+        return ExperimentTrackingConfig(
+            enabled=enabled,
+            backend=backend,
+            project=project,
+            entity=entity,
+            run_name=run_name,
+            tags=tags,
+            mode=mode,
+            root_dir=tracking_root,
+            dataset_id=self.dataset_id,
         )
 
-        return data_transformation_config
+    def get_model_trainer_config(
+        self,
+        run_name: Optional[str] = None,
+        enable_hyperparameter_search: Optional[bool] = None,
+        hyperparameter_trials: Optional[int] = None,
+    ) -> ModelTrainerConfig:
+        if self._model_trainer_config:
+            return self._model_trainer_config
 
-    def get_model_trainer_config(self) -> ModelTrainerConfig:
-        config = self.config.model_trainer
-        params = self.params.TrainingArguments
+        trainer_root = self._stage_root(self.config.model_trainer.root_dir)
+        model_dir = trainer_root / "model"
+        tokenizer_dir = trainer_root / "tokenizer"
+        run_artifacts_dir = trainer_root / "runs"
+        create_directories([model_dir, tokenizer_dir, run_artifacts_dir])
 
-        create_directories([config.root_dir])
+        run_subdir = run_name or "latest"
+        run_dir = run_artifacts_dir / run_subdir
+        create_directories([run_dir])
 
-        model_trainer_config = ModelTrainerConfig(
-            root_dir=config.root_dir,
-            data_path=config.data_path,
-            model_ckpt = config.model_ckpt,
-            num_train_epochs = params.num_train_epochs,
-            warmup_steps = params.warmup_steps,
-            per_device_train_batch_size = params.per_device_train_batch_size,
-            weight_decay = params.weight_decay,
-            logging_steps = params.logging_steps,
-            evaluation_strategy = params.evaluation_strategy,
-            eval_steps = params.evaluation_strategy,
-            save_steps = params.save_steps,
-            gradient_accumulation_steps = params.gradient_accumulation_steps
+        training_args = self.params.training.arguments.to_dict()
+        training_args["output_dir"] = str(run_dir)
+        training_args.setdefault("logging_dir", str(run_dir / "logs"))
+        training_args.setdefault("overwrite_output_dir", True)
+
+        hp_params = self.params.training.hyperparameter_search.to_dict()
+        if enable_hyperparameter_search is not None:
+            hp_params["enabled"] = bool(enable_hyperparameter_search)
+        if hyperparameter_trials is not None:
+            hp_params["n_trials"] = int(hyperparameter_trials)
+
+        hyperparameter_search_config = HyperparameterSearchConfig(
+            enabled=bool(hp_params.get("enabled", False)),
+            backend=hp_params.get("backend", "optuna"),
+            direction=hp_params.get("direction", "minimize"),
+            n_trials=int(hp_params.get("n_trials", 0)),
+            params=dict(hp_params.get("params", {})),
         )
 
-        return model_trainer_config
-    
-    def get_model_evaluation_config(self) -> ModelEvaluationConfig:
-        config = self.config.model_evaluation
+        dataset_meta = self.dataset_config
+        splits = dict(dataset_meta.splits)
 
-        create_directories([config.root_dir])
-
-        model_evaluation_config = ModelEvaluationConfig(
-            root_dir=config.root_dir,
-            data_path=config.data_path,
-            model_path = config.model_path,
-            tokenizer_path = config.tokenizer_path,
-            metric_file_name = config.metric_file_name
-           
+        config = ModelTrainerConfig(
+            dataset_id=self.dataset_id,
+            root_dir=trainer_root,
+            data_path=self.get_data_transformation_config().transformed_data_path,
+            model_ckpt=self.config.model_trainer.model_ckpt,
+            train_split=splits.get("train", "train"),
+            eval_split=splits.get("validation", "validation"),
+            training_args=training_args,
+            hyperparameter_search=hyperparameter_search_config,
+            model_dir=model_dir,
+            tokenizer_dir=tokenizer_dir,
+            run_dir=run_dir,
+            columns=dict(dataset_meta.columns),
         )
+        self._model_trainer_config = config
+        return config
 
-        return model_evaluation_config
+    def get_model_evaluation_config(self, run_name: Optional[str] = None) -> ModelEvaluationConfig:
+        if self._model_evaluation_config:
+            return self._model_evaluation_config
+
+        evaluation_root = self._stage_root(self.config.model_evaluation.root_dir)
+        metric_file = evaluation_root / "metrics.csv"
+
+        dataset_meta = self.dataset_config
+        generation_kwargs = dict(self.config.model_evaluation.generation)
+        metric_section = self.config.model_evaluation.metrics
+        metric_names = tuple(metric_section.names)
+        sample_size = metric_section.get("sample_size")
+
+        config = ModelEvaluationConfig(
+            dataset_id=self.dataset_id,
+            root_dir=evaluation_root,
+            data_path=self.get_data_transformation_config().transformed_data_path,
+            model_path=self.get_model_trainer_config(run_name=run_name).model_dir,
+            tokenizer_path=self.get_model_trainer_config(run_name=run_name).tokenizer_dir,
+            metric_file_name=metric_file,
+            splits=dict(dataset_meta.splits),
+            input_column=dataset_meta.columns.input_text,
+            target_column=dataset_meta.columns.target_text,
+            generation_kwargs=generation_kwargs,
+            metric_names=metric_names,
+            sample_size=sample_size,
+            input_max_length=int(dataset_meta.max_input_length),
+            target_max_length=int(dataset_meta.max_target_length),
+        )
+        self._model_evaluation_config = config
+        return config

--- a/src/textSummarizer/entity/__init__.py
+++ b/src/textSummarizer/entity/__init__.py
@@ -1,46 +1,98 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
 
 @dataclass(frozen=True)
 class DataIngestionConfig:
+    dataset_id: str
     root_dir: Path
-    source_URL: str
-    local_data_file: Path
-    unzip_dir: Path
+    ingestion_type: str
+    download_dir: Path
+    raw_data_dir: Path
+    dataset_path: Path
+    source_url: Optional[str] = None
+    local_data_file: Optional[Path] = None
+    extracted_folder_name: Optional[str] = None
+    huggingface_dataset: Optional[str] = None
+    huggingface_subset: Optional[str] = None
 
 
 @dataclass(frozen=True)
 class DataValidationConfig:
-    root_dir: Path
-    STATUS_FILE: str
-    ALL_REQUIRED_FILES: list
-    
-@dataclass(frozen=True)
-class DataTransformationConfig:
+    dataset_id: str
     root_dir: Path
     data_path: Path
-    tokenizer_name: Path
+    required_splits: List[str]
+    splits: Dict[str, str]
+    status_file: Path
+
+
+@dataclass(frozen=True)
+class DataTransformationConfig:
+    dataset_id: str
+    root_dir: Path
+    data_path: Path
+    tokenizer_name: str
+    input_column: str
+    target_column: str
+    max_input_length: int
+    max_target_length: int
+    transformed_data_path: Path
+    preprocessing_fn: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class HyperparameterSearchConfig:
+    enabled: bool
+    backend: str
+    direction: str
+    n_trials: int
+    params: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExperimentTrackingConfig:
+    enabled: bool
+    backend: str
+    project: Optional[str]
+    entity: Optional[str]
+    run_name: str
+    tags: Tuple[str, ...]
+    mode: Optional[str]
+    root_dir: Path
+    dataset_id: str
 
 
 @dataclass(frozen=True)
 class ModelTrainerConfig:
+    dataset_id: str
     root_dir: Path
     data_path: Path
-    model_ckpt: Path
-    num_train_epochs: int
-    warmup_steps: int
-    per_device_train_batch_size: int
-    weight_decay: float
-    logging_steps: int
-    evaluation_strategy: str
-    eval_steps: int
-    save_steps: float
-    gradient_accumulation_steps: int
+    model_ckpt: str
+    train_split: str
+    eval_split: str
+    training_args: Dict[str, Any]
+    hyperparameter_search: HyperparameterSearchConfig
+    model_dir: Path
+    tokenizer_dir: Path
+    run_dir: Path
+    columns: Dict[str, str]
+
 
 @dataclass(frozen=True)
 class ModelEvaluationConfig:
+    dataset_id: str
     root_dir: Path
     data_path: Path
     model_path: Path
     tokenizer_path: Path
     metric_file_name: Path
+    splits: Dict[str, str]
+    input_column: str
+    target_column: str
+    generation_kwargs: Dict[str, Any]
+    metric_names: Tuple[str, ...]
+    sample_size: Optional[int]
+    input_max_length: int
+    target_max_length: int

--- a/src/textSummarizer/pipeline/prediction.py
+++ b/src/textSummarizer/pipeline/prediction.py
@@ -1,25 +1,53 @@
+from threading import Lock
+from typing import Any, Dict, Optional
+
+from transformers import AutoTokenizer, pipeline
+
 from textSummarizer.config.configuration import ConfigurationManager
-from transformers import AutoTokenizer
-from transformers import pipeline
+from textSummarizer.logging import logger
 
 
 class PredictionPipeline:
-    def __init__(self):
-        self.config = ConfigurationManager().get_model_evaluation_config()
+    _pipelines: Dict[str, Any] = {}
+    _locks: Dict[str, Lock] = {}
+    _registry_lock = Lock()
 
+    def __init__(self, dataset_id: Optional[str] = None):
+        self.configuration_manager = ConfigurationManager(dataset_id=dataset_id)
+        self.config = self.configuration_manager.get_model_evaluation_config()
 
-    
-    def predict(self,text):
-        tokenizer = AutoTokenizer.from_pretrained(self.config.tokenizer_path)
-        gen_kwargs = {"length_penalty": 0.8, "num_beams":8, "max_length": 128}
+    @classmethod
+    def warmup(cls, dataset_id: Optional[str] = None) -> None:
+        instance = cls(dataset_id=dataset_id)
+        instance._get_or_create_pipeline()
 
-        pipe = pipeline("summarization", model=self.config.model_path,tokenizer=tokenizer)
+    @classmethod
+    def _get_dataset_lock(cls, dataset_id: str) -> Lock:
+        with cls._registry_lock:
+            if dataset_id not in cls._locks:
+                cls._locks[dataset_id] = Lock()
+            return cls._locks[dataset_id]
 
-        print("Dialogue:")
-        print(text)
+    def _get_or_create_pipeline(self):
+        dataset_id = self.config.dataset_id
+        if dataset_id in self._pipelines:
+            return self._pipelines[dataset_id]
+        dataset_lock = self._get_dataset_lock(dataset_id)
+        with dataset_lock:
+            if dataset_id not in self._pipelines:
+                logger.info("Loading summarization pipeline for dataset '%s'", dataset_id)
+                tokenizer = AutoTokenizer.from_pretrained(self.config.tokenizer_path)
+                summarizer = pipeline(
+                    "summarization",
+                    model=str(self.config.model_path),
+                    tokenizer=tokenizer,
+                )
+                self._pipelines[dataset_id] = summarizer
+        return self._pipelines[dataset_id]
 
-        output = pipe(text, **gen_kwargs)[0]["summary_text"]
-        print("\nModel Summary:")
-        print(output)
-
-        return output
+    def predict(self, text: str) -> str:
+        summarizer = self._get_or_create_pipeline()
+        logger.debug("Running prediction for dataset '%s'", self.config.dataset_id)
+        result = summarizer(text, **self.config.generation_kwargs)
+        summary = result[0]["summary_text"] if result else ""
+        return summary

--- a/src/textSummarizer/pipeline/stage1_data_ingestion.py
+++ b/src/textSummarizer/pipeline/stage1_data_ingestion.py
@@ -1,15 +1,14 @@
-from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.components.data_ingestion import DataIngestion
+from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.logging import logger
 
 
 class DataIngestionTrainingPipeline:
-    def __init__(self):
-        pass
+    def __init__(self, configuration: ConfigurationManager):
+        self.configuration = configuration
 
-    def main(self):
-        config = ConfigurationManager()
-        data_ingestion_config = config.get_data_ingestion_config()
+    def main(self) -> None:
+        data_ingestion_config = self.configuration.get_data_ingestion_config()
         data_ingestion = DataIngestion(config=data_ingestion_config)
-        data_ingestion.download_file()
-        data_ingestion.extract_zip_file()
+        data_ingestion.run()
+        logger.info("Data ingestion stage completed for dataset '%s'", data_ingestion_config.dataset_id)

--- a/src/textSummarizer/pipeline/stage2_data_validation.py
+++ b/src/textSummarizer/pipeline/stage2_data_validation.py
@@ -1,14 +1,16 @@
-from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.components.data_validation import DataValidation
+from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.logging import logger
 
 
 class DataValidationTrainingPipeline:
-    def __init__(self):
-        pass
+    def __init__(self, configuration: ConfigurationManager):
+        self.configuration = configuration
 
-    def main(self):
-        config = ConfigurationManager()
-        data_validation_config = config.get_data_validation_config()
-        data_validation = DataValidation(config=data_validation_config)
-        data_validation.validate_all_files_exist()
+    def main(self) -> None:
+        validation_config = self.configuration.get_data_validation_config()
+        validator = DataValidation(config=validation_config)
+        status = validator.validate_all_files_exist()
+        if not status:
+            raise RuntimeError("Data validation failed. Please ensure all required splits are available.")
+        logger.info("Data validation successful for dataset '%s'", validation_config.dataset_id)

--- a/src/textSummarizer/pipeline/stage3_data_transformation.py
+++ b/src/textSummarizer/pipeline/stage3_data_transformation.py
@@ -1,14 +1,14 @@
-from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.components.data_transformation import DataTransformation
+from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.logging import logger
 
 
 class DataTransformationTrainingPipeline:
-    def __init__(self):
-        pass
+    def __init__(self, configuration: ConfigurationManager):
+        self.configuration = configuration
 
-    def main(self):
-        config = ConfigurationManager()
-        data_transformation_config = config.get_data_transformation_config()
-        data_transformation = DataTransformation(config=data_transformation_config)
-        data_transformation.convert()
+    def main(self) -> None:
+        transformation_config = self.configuration.get_data_transformation_config()
+        transformer = DataTransformation(config=transformation_config)
+        transformer.convert()
+        logger.info("Data transformation completed for dataset '%s'", transformation_config.dataset_id)

--- a/src/textSummarizer/pipeline/stage4_model_trainer.py
+++ b/src/textSummarizer/pipeline/stage4_model_trainer.py
@@ -1,14 +1,33 @@
-from textSummarizer.config.configuration import ConfigurationManager
+from typing import Optional
+
 from textSummarizer.components.model_trainer import ModelTrainer
+from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.logging import logger
 
 
 class ModelTrainerTrainingPipeline:
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        configuration: ConfigurationManager,
+        run_name: Optional[str] = None,
+        enable_hyperparameter_search: Optional[bool] = None,
+        hyperparameter_trials: Optional[int] = None,
+    ):
+        self.configuration = configuration
+        self.run_name = run_name
+        self.enable_hyperparameter_search = enable_hyperparameter_search
+        self.hyperparameter_trials = hyperparameter_trials
 
-    def main(self):
-        config = ConfigurationManager()
-        model_trainer_config = config.get_model_trainer_config()
-        model_trainer_config = ModelTrainer(config=model_trainer_config)
-        model_trainer_config.train()
+    def main(self) -> None:
+        tracking_config = self.configuration.get_experiment_tracking_config(
+            run_name_override=self.run_name,
+            stage="train",
+        )
+        trainer_config = self.configuration.get_model_trainer_config(
+            run_name=tracking_config.run_name,
+            enable_hyperparameter_search=self.enable_hyperparameter_search,
+            hyperparameter_trials=self.hyperparameter_trials,
+        )
+        trainer = ModelTrainer(config=trainer_config, tracking_config=tracking_config)
+        trainer.train()
+        logger.info("Model training completed for dataset '%s'", trainer_config.dataset_id)

--- a/src/textSummarizer/pipeline/stage5_model_evaluation.py
+++ b/src/textSummarizer/pipeline/stage5_model_evaluation.py
@@ -1,16 +1,21 @@
-from textSummarizer.config.configuration import ConfigurationManager
+from typing import Optional
+
 from textSummarizer.components.model_evaluation import ModelEvaluation
+from textSummarizer.config.configuration import ConfigurationManager
 from textSummarizer.logging import logger
 
 
-
-
 class ModelEvaluationTrainingPipeline:
-    def __init__(self):
-        pass
+    def __init__(self, configuration: ConfigurationManager, run_name: Optional[str] = None):
+        self.configuration = configuration
+        self.run_name = run_name
 
-    def main(self):
-        config = ConfigurationManager()
-        model_evaluation_config = config.get_model_evaluation_config()
-        model_evaluation_config = ModelEvaluation(config=model_evaluation_config)
-        model_evaluation_config.evaluate()
+    def main(self) -> None:
+        evaluation_config = self.configuration.get_model_evaluation_config(run_name=self.run_name)
+        tracking_config = self.configuration.get_experiment_tracking_config(
+            run_name_override=self.run_name,
+            stage="evaluation",
+        )
+        evaluator = ModelEvaluation(config=evaluation_config, tracking_config=tracking_config)
+        metrics = evaluator.evaluate()
+        logger.info("Evaluation metrics for dataset '%s': %s", evaluation_config.dataset_id, metrics)

--- a/src/textSummarizer/pipeline/training.py
+++ b/src/textSummarizer/pipeline/training.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+from textSummarizer.config.configuration import ConfigurationManager
+from textSummarizer.logging import logger
+from textSummarizer.pipeline.stage1_data_ingestion import DataIngestionTrainingPipeline
+from textSummarizer.pipeline.stage2_data_validation import DataValidationTrainingPipeline
+from textSummarizer.pipeline.stage3_data_transformation import DataTransformationTrainingPipeline
+from textSummarizer.pipeline.stage4_model_trainer import ModelTrainerTrainingPipeline
+from textSummarizer.pipeline.stage5_model_evaluation import ModelEvaluationTrainingPipeline
+
+
+def run_training_pipeline(
+    dataset_id: Optional[str] = None,
+    enable_hyperparameter_search: Optional[bool] = None,
+    hyperparameter_trials: Optional[int] = None,
+    experiment_name: Optional[str] = None,
+) -> str:
+    """Execute the end-to-end training workflow for the selected dataset."""
+
+    configuration_manager = ConfigurationManager(dataset_id=dataset_id)
+    dataset_label = configuration_manager.dataset_id
+    logger.info("Starting training pipeline for dataset '%s'", dataset_label)
+
+    ingestion_pipeline = DataIngestionTrainingPipeline(configuration_manager)
+    ingestion_pipeline.main()
+
+    validation_pipeline = DataValidationTrainingPipeline(configuration_manager)
+    validation_pipeline.main()
+
+    transformation_pipeline = DataTransformationTrainingPipeline(configuration_manager)
+    transformation_pipeline.main()
+
+    trainer_pipeline = ModelTrainerTrainingPipeline(
+        configuration=configuration_manager,
+        run_name=experiment_name,
+        enable_hyperparameter_search=enable_hyperparameter_search,
+        hyperparameter_trials=hyperparameter_trials,
+    )
+    trainer_pipeline.main()
+
+    evaluation_pipeline = ModelEvaluationTrainingPipeline(
+        configuration=configuration_manager,
+        run_name=experiment_name,
+    )
+    evaluation_pipeline.main()
+
+    logger.info("Training pipeline finished for dataset '%s'", dataset_label)
+    return dataset_label

--- a/src/textSummarizer/service/training_jobs.py
+++ b/src/textSummarizer/service/training_jobs.py
@@ -1,0 +1,85 @@
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, Optional
+
+from textSummarizer.logging import logger
+from textSummarizer.pipeline.training import run_training_pipeline
+
+
+class TrainingJobManager:
+    def __init__(self, max_workers: int = 1):
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._jobs: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def submit(
+        self,
+        dataset_id: Optional[str] = None,
+        enable_hyperparameter_search: Optional[bool] = None,
+        hyperparameter_trials: Optional[int] = None,
+        experiment_name: Optional[str] = None,
+    ) -> str:
+        job_id = str(uuid.uuid4())
+        job_info = {
+            "job_id": job_id,
+            "dataset_id": dataset_id,
+            "status": "queued",
+            "submitted_at": time.time(),
+            "started_at": None,
+            "finished_at": None,
+            "error": None,
+            "experiment_name": experiment_name,
+        }
+        with self._lock:
+            self._jobs[job_id] = job_info
+        self._executor.submit(
+            self._run_job,
+            job_id,
+            dataset_id,
+            enable_hyperparameter_search,
+            hyperparameter_trials,
+            experiment_name,
+        )
+        return job_id
+
+    def _run_job(
+        self,
+        job_id: str,
+        dataset_id: Optional[str],
+        enable_hyperparameter_search: Optional[bool],
+        hyperparameter_trials: Optional[int],
+        experiment_name: Optional[str],
+    ) -> None:
+        with self._lock:
+            self._jobs[job_id]["status"] = "running"
+            self._jobs[job_id]["started_at"] = time.time()
+        try:
+            run_training_pipeline(
+                dataset_id=dataset_id,
+                enable_hyperparameter_search=enable_hyperparameter_search,
+                hyperparameter_trials=hyperparameter_trials,
+                experiment_name=experiment_name,
+            )
+            status = "completed"
+            error = None
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Training job %s failed", job_id)
+            status = "failed"
+            error = str(exc)
+        with self._lock:
+            self._jobs[job_id]["status"] = status
+            self._jobs[job_id]["finished_at"] = time.time()
+            self._jobs[job_id]["error"] = error
+
+    def get(self, job_id: str) -> Dict[str, Any]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                raise KeyError(job_id)
+            return dict(job)
+
+    def list_jobs(self) -> Dict[str, Dict[str, Any]]:
+        with self._lock:
+            return {job_id: dict(info) for job_id, info in self._jobs.items()}

--- a/src/textSummarizer/utils/common.py
+++ b/src/textSummarizer/utils/common.py
@@ -1,66 +1,52 @@
+import importlib
 import os
+from box import ConfigBox
 from box.exceptions import BoxValueError
+from ensure import ensure_annotations
+from pathlib import Path
+from typing import Any, Callable, List
 import yaml
 from textSummarizer.logging import logger
-from ensure import ensure_annotations
-from box import ConfigBox
-from pathlib import Path
-from typing import Any
-
 
 
 @ensure_annotations
 def read_yaml(path_to_yaml: Path) -> ConfigBox:
-    """reads yaml file and returns
-
-    Args:
-        path_to_yaml (str): path like input
-
-    Raises:
-        ValueError: if yaml file is empty
-        e: empty file
-
-    Returns:
-        ConfigBox: ConfigBox type
-    """
+    """Read a YAML file and return its content as a ConfigBox."""
     try:
         with open(path_to_yaml) as yaml_file:
             content = yaml.safe_load(yaml_file)
             logger.info(f"yaml file: {path_to_yaml} loaded successfully")
             return ConfigBox(content)
-    except BoxValueError:
-        raise ValueError("yaml file is empty")
-    except Exception as e:
-        raise e
-    
+    except BoxValueError as exc:
+        raise ValueError("yaml file is empty") from exc
+    except Exception as exc:
+        raise exc
 
 
 @ensure_annotations
-def create_directories(path_to_directories: list, verbose=True):
-    """create list of directories
-
-    Args:
-        path_to_directories (list): list of path of directories
-        ignore_log (bool, optional): ignore if multiple dirs is to be created. Defaults to False.
-    """
+def create_directories(path_to_directories: List[Path], verbose: bool = True) -> None:
+    """Create the provided directories if they do not exist."""
     for path in path_to_directories:
         os.makedirs(path, exist_ok=True)
         if verbose:
             logger.info(f"created directory at: {path}")
 
 
-
 @ensure_annotations
 def get_size(path: Path) -> str:
-    """get size in KB
-
-    Args:
-        path (Path): path of the file
-
-    Returns:
-        str: size in KB
-    """
-    size_in_kb = round(os.path.getsize(path)/1024)
+    """Return the file size in kilobytes."""
+    size_in_kb = round(os.path.getsize(path) / 1024)
     return f"~ {size_in_kb} KB"
 
-    
+
+@ensure_annotations
+def import_from_string(dotted_path: str) -> Callable[..., Any]:
+    """Import a callable using a dotted module path."""
+    module_path, _, attribute = dotted_path.rpartition(".")
+    if not module_path:
+        raise ImportError(f"Unable to import '{dotted_path}'. Provide a full dotted path.")
+    module = importlib.import_module(module_path)
+    try:
+        return getattr(module, attribute)
+    except AttributeError as exc:
+        raise ImportError(f"Module '{module_path}' does not define '{attribute}'.") from exc

--- a/src/textSummarizer/utils/tracking.py
+++ b/src/textSummarizer/utils/tracking.py
@@ -1,0 +1,128 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from transformers.trainer_callback import TrainerCallback
+
+from textSummarizer.entity import ExperimentTrackingConfig
+from textSummarizer.logging import logger
+
+
+class ExperimentTracker:
+    """Lightweight abstraction over experiment tracking backends."""
+
+    def __init__(self, config: ExperimentTrackingConfig):
+        self.config = config
+        self.enabled = bool(config.enabled)
+        self.backend = (config.backend or "local").lower()
+        self._run_started = False
+        self._log_file: Optional[Path] = None
+        self._metadata_file: Optional[Path] = None
+        self._wandb_run = None
+
+        if self.enabled and self.backend not in {"local", "wandb"}:
+            raise ValueError(f"Unsupported experiment tracking backend: {self.backend}")
+
+    @property
+    def run_dir(self) -> Path:
+        return Path(self.config.root_dir) / self.config.run_name
+
+    def start_run(self, params: Optional[Dict[str, Any]] = None) -> None:
+        if not self.enabled or self._run_started:
+            return
+
+        params = params or {}
+        if self.backend == "local":
+            run_dir = self.run_dir
+            run_dir.mkdir(parents=True, exist_ok=True)
+            self._log_file = run_dir / "metrics.jsonl"
+            self._metadata_file = run_dir / "metadata.json"
+            metadata = {
+                "run_name": self.config.run_name,
+                "dataset_id": self.config.dataset_id,
+                "backend": self.backend,
+                "tags": list(self.config.tags),
+                "project": self.config.project,
+                "entity": self.config.entity,
+                "mode": self.config.mode,
+                "params": params,
+                "started_at": datetime.utcnow().isoformat(),
+            }
+            with open(self._metadata_file, "w", encoding="utf-8") as meta_file:
+                json.dump(metadata, meta_file, indent=2)
+        elif self.backend == "wandb":
+            try:
+                import wandb
+            except ImportError as exc:
+                raise RuntimeError("W&B backend requested but package 'wandb' is not installed.") from exc
+            if self.config.mode:
+                os.environ.setdefault("WANDB_MODE", self.config.mode)
+            self._wandb_run = wandb.init(
+                project=self.config.project,
+                entity=self.config.entity,
+                name=self.config.run_name,
+                tags=list(self.config.tags) or None,
+                reinit=True,
+            )
+            if params:
+                self._wandb_run.config.update(params, allow_val_change=True)
+        self._run_started = True
+        logger.info("Experiment tracking run '%s' started (backend=%s)", self.config.run_name, self.backend)
+
+    def log_params(self, params: Dict[str, Any]) -> None:
+        if not self.enabled or not params:
+            return
+        if self.backend == "local" and self._metadata_file:
+            with open(self._metadata_file, "r", encoding="utf-8") as meta_file:
+                metadata = json.load(meta_file)
+            metadata.setdefault("params", {}).update(params)
+            with open(self._metadata_file, "w", encoding="utf-8") as meta_file:
+                json.dump(metadata, meta_file, indent=2)
+        elif self.backend == "wandb" and self._wandb_run:
+            self._wandb_run.config.update(params, allow_val_change=True)
+
+    def log_metrics(self, metrics: Dict[str, Any], step: Optional[int] = None) -> None:
+        if not self.enabled or not metrics:
+            return
+        if self.backend == "local" and self._log_file:
+            entry = {
+                "step": step,
+                "metrics": metrics,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+            with open(self._log_file, "a", encoding="utf-8") as log_file:
+                log_file.write(json.dumps(entry) + "\n")
+        elif self.backend == "wandb" and self._wandb_run:
+            import wandb
+
+            wandb.log(metrics, step=step)
+
+    def finish(self) -> None:
+        if not self.enabled or not self._run_started:
+            return
+        if self.backend == "local" and self._metadata_file:
+            with open(self._metadata_file, "r", encoding="utf-8") as meta_file:
+                metadata = json.load(meta_file)
+            metadata["finished_at"] = datetime.utcnow().isoformat()
+            with open(self._metadata_file, "w", encoding="utf-8") as meta_file:
+                json.dump(metadata, meta_file, indent=2)
+        elif self.backend == "wandb" and self._wandb_run:
+            import wandb
+
+            wandb.finish()
+            self._wandb_run = None
+        self._run_started = False
+        logger.info("Experiment tracking run '%s' finished", self.config.run_name)
+
+
+class ExperimentTrackerCallback(TrainerCallback):
+    """Hook Trainer logs into the experiment tracker."""
+
+    def __init__(self, tracker: ExperimentTracker):
+        self.tracker = tracker
+
+    def on_log(self, args, state, control, logs=None, **kwargs):  # type: ignore[override]
+        if logs:
+            self.tracker.log_metrics(logs, step=state.global_step)


### PR DESCRIPTION
## Summary
- add a dataset registry with dataset-aware configuration management and typed configs
- integrate hyperparameter search plus experiment tracking utilities into training and evaluation stages
- overhaul the FastAPI app to expose dataset discovery, background training jobs, and cached prediction pipelines

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd962b38a88328b5add5d5a8b8c30d